### PR TITLE
Ability to configure level for  ObservableEventListener.FromTraceEvent

### DIFF
--- a/EtwStream.Core/EtwStream.Core.csproj
+++ b/EtwStream.Core/EtwStream.Core.csproj
@@ -69,6 +69,7 @@
     <Compile Include="ObservableEventListener.TraceEvent.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TraceEventExtensions.cs" />
+    <Compile Include="TraceEventProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="EtwStream.snk" />

--- a/EtwStream.Core/ObservableEventListener.TraceEvent.cs
+++ b/EtwStream.Core/ObservableEventListener.TraceEvent.cs
@@ -38,7 +38,7 @@ namespace EtwStream
         /// <summary>
         /// Observe Out-of-Process ETW Realtime session by provider Name or string Guid with Level.
         /// </summary>
-        /// <param name="providerNameOrGuid">e.g.'MyEventSource'</param>
+        /// <param name="providers">e.g.'MyEventSource'</param>
         public static IObservable<TraceEvent> FromTraceEvent(params TraceEventProvider[] providers)
         {
             IConnectableObservable<TraceEvent> source;

--- a/EtwStream.Core/TraceEventProvider.cs
+++ b/EtwStream.Core/TraceEventProvider.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Session;
+
+namespace EtwStream
+{
+    public class TraceEventProvider
+    {
+        public Guid Guid;
+        public TraceEventLevel Level;
+
+        public TraceEventProvider(string nameOrGuid, TraceEventLevel level = TraceEventLevel.Verbose)
+        {
+            if (!Guid.TryParse(nameOrGuid, out Guid))
+            {
+                Guid = TraceEventProviders.GetEventSourceGuidFromName(nameOrGuid);
+            }
+            Level = level;
+        }
+
+        public TraceEventProvider(Guid guid, TraceEventLevel level = TraceEventLevel.Verbose)
+        {
+            Guid = guid;
+            Level = level;
+        }
+    }
+}


### PR DESCRIPTION
New overload for ObservableEventListener.FromTraceEvent to subscribe with pairs level/name, so it's not just Verbose level only
